### PR TITLE
Add back parameter to `get_conversation.sql` query

### DIFF
--- a/queries/get_conversation.sql
+++ b/queries/get_conversation.sql
@@ -9,5 +9,5 @@ SELECT
     m.created_at AS message_created_at
 FROM conversations c 
     LEFT JOIN messages m ON c.id = m.conversation_id
-WHERE c.id
+WHERE c.id = ?
 ORDER BY m.created_at DESC;


### PR DESCRIPTION
### TL;DR
Added a parameter placeholder to `get_conversation.sql` query to ensure proper query execution.

### What changed?
Modified the SQL query in `get_conversation.sql` to include a parameter placeholder (`?`) for the conversation ID, enabling prepared statements to safely pass the parameter.

### How to test?
1. Execute the modified `get_conversation.sql` query in your SQL environment with different conversation IDs.
2. Verify the output returns the correct messages for each conversation ID tested.

### Why make this change?
This change was made to ensure the query uses a placeholder for the conversation ID, which enhances security by preventing SQL injection and supports dynamic query execution.

---

### TL;DR
Leave a brief summary of the change

### What changed?
Describe the change

### How to test?
Leave instructions for testing

### Why make this change?
Describe the motivation/reason behind this change

---

